### PR TITLE
Add parallelization option, make new test plans get written to the project file

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ From the folder you downloaded this code open the terminal and run:
 **Debug (required)**
   * **Description:** Show verbose debug logs
   * **Example:** `true`
+  
+  **Parallelizable (optional)**
+    * **Description:** Allow each shard to run multiple simulators in parallel
+    * **Example:** `true`
 
 ## Outputs
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const TARGET = process.env.target;
 const TEST_PATH = process.env.test_path;
 const SCHEME = process.env.scheme;
 const DEBUG = process.env.debug_mode == 'true' ? true : false;
+const PARALLELIZABLE = process.env.parallelizable == 'true' ? true : false;
 
 console.log('XCODE_PATH:',XCODE_PATH)
 console.log('XCODE_PROJECT:',XCODE_PROJECT)
@@ -358,6 +359,7 @@ function getMainTarget(schemeJson, skippedShardTests){
                     let allSkippedTests = skippedTests.concat(skippedShardTests)
                     target = {
                         "skippedTests" : allSkippedTests,
+                        "parallelizable" : PARALLELIZABLE,
                         "target" : {
                             "containerPath" : buildableReference.ReferencedContainer.replace(/\//g, "~"),
                             "identifier" : buildableReference.BlueprintIdentifier,

--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ function addTestPlans(main_group_uuid, shards){
             });
             
             log('Writing Test Plan to file');
-            fs.writeFileSync(shardName, createTestPlan(defaultOptions, [mainTarget].concat(shardTargets).concat(allDisabledShards)));
+            fs.writeFileSync(XCODE_PATH + shardName, createTestPlan(defaultOptions, [mainTarget].concat(shardTargets).concat(allDisabledShards)));
 
             console.log('Test Plan Shard '+shardIndex+' Created:', shardName);
         })

--- a/step.yml
+++ b/step.yml
@@ -156,6 +156,16 @@ inputs:
       value_options:
         - "false"
         - "true"
+  - parallelizable: "false"
+    opts:
+      title: "Enable Simulator Parallelization"
+      summary: Each shard will run its tests in parallel if enabled.
+      description: Each shard will run its tests in parallel if enabled.
+      is_required: true
+      is_sensitive: false
+      value_options:
+        - "false"
+        - "true"
 outputs:
   - TEST_PLANS:
     opts:

--- a/step.yml
+++ b/step.yml
@@ -73,6 +73,10 @@ description: |-
   **Debug**
     * **Description:** Create verbose debug logs
     * **Example:** YES / NO
+    
+  **Parallelizable**
+    * **Description:** Allow shards to run tests with multiple simulators in parallel
+    * **Example:** YES / NO
 
   ## Outputs
 


### PR DESCRIPTION
This PR does two main things:

- Adds an option to enable parallelization for test shards. This allows each shard to be able to run its tests in parallel in addition to splitting the tests across shards

- Updates the location of new test plans to be created in the folder containing the xcode project rather than the folder containing the test sharder.  This is where the scheme expects them to be, so this prevents an extra step of moving the new test plans afterwards.