### PR TITLE
Better shard balancing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 // Inputs
+const XCODE_PATH = process.env.path_to_xcode + '/';
+const XCODE_PROJECT = process.env.xcode_project;
 const SHARDS = process.env.shards;
 const TEST_PLAN = process.env.test_plan;
 const TARGET = process.env.target;

--- a/index.js
+++ b/index.js
@@ -491,13 +491,17 @@ function createTestPlan(defaultOptions, testTargets){
 
 function shard(arr, numShards) {
     const newArr = [];
+    // initialize array of shards
     for (let s = 0; s < numShards; s++) {
         newArr.push([])
     }
+
+    // iterate through shards to maintain balance
     for (let i = 0; i < arr.length; i++) {
-        const mod = i % numCols
+        const mod = i % numShards
         newArr[mod].push(arr[i])
     }
+
     return newArray
 }
 

--- a/index.js
+++ b/index.js
@@ -502,7 +502,7 @@ function shard(arr, numShards) {
         newArr[mod].push(arr[i])
     }
 
-    return newArray
+    return newArr
 }
 
 function log(msg, obj){

--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
 // Inputs
-const XCODE_PATH = process.env.path_to_xcode + '/';
-const XCODE_PROJECT = process.env.xcode_project;
 const SHARDS = process.env.shards;
 const TEST_PLAN = process.env.test_plan;
 const TARGET = process.env.target;
@@ -75,8 +73,7 @@ myProj.parse(function (err) {
 
     log("Tests found in test path: ", classNameTests.length);
 
-    const shard_size = Math.ceil(classNameTests.length / SHARDS);
-    const classNameShards = shard(classNameTests, shard_size);
+    const classNameShards = shard(classNameTests, SHARDS);
     log('Shards: ', classNameShards.length)
 
     if(DEBUG){
@@ -145,8 +142,7 @@ function updateTestPlan(shards){
         let testPlanJson = JSON.parse(jsonString.replace(/\\\//g, "~"));
         let otherTargets = testPlanJson.testTargets.filter((target) => target.target.name != TARGET)
 
-        const target_shard_size = Math.ceil(otherTargets.length / SHARDS);
-        const otherTargetsShards = shard(otherTargets, target_shard_size);
+        const otherTargetsShards = shard(otherTargets, SHARDS);
 
         log('otherTargetsShards:', otherTargetsShards);
 
@@ -225,8 +221,7 @@ function addTestPlans(main_group_uuid, shards){
         let defaultOptions = getDefaulOptions(schemeJson);
 
         let otherTargets = getOtherTargets(schemeJson);
-        const target_shard_size = Math.ceil(otherTargets.length / SHARDS);
-        const otherTargetsShards = shard(otherTargets, target_shard_size);
+        const otherTargetsShards = shard(otherTargets, SHARDS);
 
         log('otherTargetsShards:', otherTargetsShards);
 
@@ -492,14 +487,16 @@ function createTestPlan(defaultOptions, testTargets){
     return JSON.stringify(testPlan).replace(/~/g, '\\/');
 }
 
-function shard(arr, howMany) {
-    let newArr = []; start = 0; end = howMany;
-    for(let i=1; i<= Math.ceil(arr.length / howMany); i++) {
-        newArr.push(arr.slice(start, end));
-        start = start + howMany;
-        end = end + howMany
+function shard(arr, numShards) {
+    const newArr = [];
+    for (let s = 0; s < numShards; s++) {
+        newArr.push([])
     }
-    return newArr;
+    for (let i = 0; i < arr.length; i++) {
+        const mod = i % numCols
+        newArr[mod].push(arr[i])
+    }
+    return newArray
 }
 
 function log(msg, obj){


### PR DESCRIPTION
Currently shards are given a number of tests equal to ceiling(numTests / numShards), which can lead to some shards getting many fewer tests than others. This change instead iterates through the tests to improve shard balance

Examples:
The screenshot below is how the shard balance currently works, this was with 37 tests and 9 shards.
<img width="275" alt="Screen Shot 2020-12-08 at 1 04 19 PM" src="https://user-images.githubusercontent.com/23284241/101656894-3f8d1e00-3a11-11eb-95ca-9b4020bd915c.png">
Note: Even though 9 shards were requested, only 8 ended up being created
So the current result is:
- 7 shards with 5 tests
- 1 shard with 2 tests
- 1 shard with 0 tests


This pr instead changes the balance to the following:
<img width="269" alt="Screen Shot 2020-12-08 at 1 28 49 PM" src="https://user-images.githubusercontent.com/23284241/101657335-c215dd80-3a11-11eb-8b12-d73e4d776669.png">
The new result is: 
- 1 shard with 5 tests
- 8 shards with 4 tests
